### PR TITLE
src/main.py.in: remove code using deprecated API

### DIFF
--- a/src/main.py.in
+++ b/src/main.py.in
@@ -91,10 +91,6 @@ class IMApp:
         # for engineunit in self.__bus.list_engines():
         #    print("list:" + engineunit.get_name())
 
-        for activeengine in self.__bus.list_active_engines():
-            print("active list:" + activeengine.get_name())
-
-            
     def run(self):
         self.__mainloop.run()
 


### PR DESCRIPTION
list_active_engines is deprecated since ibus 1.5.3.

You can get active enignes reading dconf value
/desktop/ibus/general/preload-engines by following command.

$ dconf read /desktop/ibus/general/preload-engines